### PR TITLE
Mattcridland/laser whitelist

### DIFF
--- a/tplink/laserboss.lua
+++ b/tplink/laserboss.lua
@@ -7,6 +7,10 @@ COST_PER_MIN = 0.5
 USB_PATH = "/sys/bus/usb/devices/usb1/authorized"
 UPDATE_INTERVAL = 3600
 RETRY_INTERVAL = 300
+
+BASE_RFID_URL = "https://www.acemonstertoys.org/export/"
+LASER_EXTENSION = "laser/"
+MEMBER_EXTENSION = "rfids/"
 -- a file with LASER_KEY and WP_KEY API keys defined (not public)
 dofile("/root/key.lua")
 

--- a/tplink/laserboss.lua
+++ b/tplink/laserboss.lua
@@ -3,7 +3,7 @@
 PORT_NAME = "/dev/ttyACM0"
 READ_TIMEOUT = 2000	-- in ms
 DB_FILE = "/root/laser.db"
-COST_PER_MIN = 0.25
+COST_PER_MIN = 0.5
 USB_PATH = "/sys/bus/usb/devices/usb1/authorized"
 UPDATE_INTERVAL = 3600
 RETRY_INTERVAL = 300
@@ -21,7 +21,7 @@ conn:commit()
 rs232 = require("luars232")
 
 -- socket library
-http = require("socket.http")
+https = require("ssl.https")
 ltn12 = require("ltn12")
 
 
@@ -175,27 +175,27 @@ function display_active (odo_start, odo)
 	local minutes = math.floor((odo-odo_start)/60)
 	local seconds = (odo-odo_start) % 60
 	display(" Time:   Cost:", string.format("%3.0f",minutes) .. ":" ..
-				string.format("%02.0f",seconds) .. "   $" .. 
+				string.format("%02.0f",seconds) .. "   $" ..
 				string.format("%3.2f", COST_PER_MIN * (odo-odo_start)/60))
 end
 
 function is_valid_user(userid)
 	return (active_keys == nil or active_keys[userid] ~= nil)
 end
-	
+
 local isEnabled = false
 local user, odo_start
 local time_last_update = os.time()
 local time_last_jrnl = 0
 journal_dirty = true
-try(function() 
+try(function()
 	update_keys()
 end, function(e)
 	logger("Could not load key list")
 	print(e)
 end)
 
-try(function() 
+try(function()
 	open_port()
 	set_enabled(false)
 end, function(e)
@@ -210,7 +210,7 @@ while true do
 		odo, scanned = get_status()
 		assert(odo ~= nil and scanned ~= nil, "Status is invalid")
 		if os.time() - time_last_update > UPDATE_INTERVAL then
-			try(function() 
+			try(function()
 				update_keys()
 				time_last_update = os.time()
 			end, function(e)
@@ -219,8 +219,8 @@ while true do
 				time_last_update = time_last_update + RETRY_INTERVAL
 			end)
 		end
-		
-		try(function() 
+
+		try(function()
 			if (journal_dirty and os.time() - time_last_jrnl > RETRY_INTERVAL) then
 				upload_journal()
 				journal_dirty = false
@@ -231,9 +231,9 @@ while true do
 			logger("Failed to upload journal")
 			print("Failed to upload journal: ", e)
 		end)
-		
+
 		set_enabled(isEnabled)
-		
+
 		if isEnabled then
 			if scanned == "1" then
 				-- sign out
@@ -249,7 +249,7 @@ while true do
 						display("Welcome new user")
 						os.execute("sleep 1")
 						odo_start = odo
-					else	
+					else
 						logger("Attempted login from inactive fob: " .. user2)
 						display("Fob not active")
 						set_enabled(false)
@@ -298,7 +298,7 @@ while true do
 		repeat
 			logger("Trying to reset port")
 			os.execute("sleep 1")
-			try(function() 
+			try(function()
 				if p ~= nil then
 					p:close()
 				end

--- a/tplink/laserboss.lua
+++ b/tplink/laserboss.lua
@@ -21,6 +21,7 @@ conn:commit()
 rs232 = require("luars232")
 
 -- socket library
+http = requrie("socket.http")
 https = require("ssl.https")
 ltn12 = require("ltn12")
 
@@ -66,8 +67,6 @@ function update_keys()
   active_keys = download_keys(MEMBER_EXTENSION)
   laser_keys = download_keys(LASER_EXTENSION)
 end
-
-update_keys()
 
 function submit_event(ts, evtype, userid, odo)
 	local t = {}
@@ -189,7 +188,11 @@ function display_active (odo_start, odo)
 end
 
 function is_valid_user(userid)
-	return (active_keys == nil or active_keys[userid] ~= nil)
+	return (laser_keys[userid] ~= nil)
+end
+
+function is_valid_member(userid)
+  return (active_keys[userid] ~= nil)
 end
 
 local isEnabled = false
@@ -259,8 +262,13 @@ while true do
 						os.execute("sleep 1")
 						odo_start = odo
 					else
-						logger("Attempted login from inactive fob: " .. user2)
-						display("Fob not active")
+            if is_valid_member(user2) then
+              logger("Attempted login from non certified member: " .. user2)
+              display("Not certified")
+            else
+						  logger("Attempted login from inactive fob: " .. user2)
+						  display("Fob not active")
+            end
 						set_enabled(false)
 						isEnabled = false
 						os.execute("sleep 5")
@@ -292,8 +300,13 @@ while true do
 					display("Welcome!")
 					os.execute("sleep 2")
 				else
-					logger("Attempted login from inactive fob: " .. user)
-					display("Fob not active")
+          if is_valid_member(user) then
+            logger("Attempted login from non certified member: " .. user)
+            display("Not certified")
+          else
+            logger("Attempted login from inactive fob: " .. user)
+					  display("Fob not active")
+          end
 					os.execute("sleep 5")
 				end
 			else


### PR DESCRIPTION
Changed:
 - Usage rate to 50p per minute
 - Endpoint to new export endpoints

Added:
 - Https support (required for new endpoints)
 - Laser whitelist
 - Extra user message / logging for member not certified login attempt

SETUP:
 - These changes require luasec for https to work, install through luarocks or preferred method before testing.

STATUS:
 - Tested on Linux debain with lua 5.3, luasec 0.9-1, luasocket 3.0rc1-2, and socketssl 1.1.1 
 - Requires testing on fob box