### PR TITLE
switching to TTL pin from TTL- pin on controller

### DIFF
--- a/teensy/laser_worker/laser_worker.ino
+++ b/teensy/laser_worker/laser_worker.ino
@@ -18,10 +18,10 @@
 #define LASER_PIN 			0
 // 5v from laser power supply
 #define LASER_POWER_PIN 	1
-// laser pin is active low
-#define LASER_PIN_FIRING	0
+// laser pin is active high (Light Object T9+ controller TTL pin, not TTL- pin)
+#define LASER_PIN_FIRING	HIGH
 // power pin is active high
-#define LASER_PIN_PWR_ON	1
+#define LASER_PIN_PWR_ON	HIGH
 
 // Relay to enable or disable the laser
 #define ENABLE_PIN 10
@@ -135,7 +135,7 @@ void loop()
 			case 'x':
 				if (serialByte == '\n')
 				{
-					time_total = 1000;
+					time_total = 1;  // Seconds
 					write_odo();
 					serialCommand = 0;
 				}


### PR DESCRIPTION
When the fob box is unplugged while the laser is on, the laser starts firing.  Even when the door is open.  
This is because the T9+ controller's TTL- (inverting) pin is being pulled to ground through the other electronics on the box.

The T9+ has a TTL pin (non-inverting) pin which is not connected directly to the laser power supply.  We sense the laser being on from there, which is active HIGH.